### PR TITLE
Replace deprecated torch.solve()

### DIFF
--- a/torchesn/nn/echo_state_network.py
+++ b/torchesn/nn/echo_state_network.py
@@ -234,9 +234,9 @@ class ESN(nn.Module):
             return
 
         if self.readout_training == 'cholesky':
-            W = torch.solve(self.XTy,
-                           self.XTX + self.lambda_reg * torch.eye(
-                               self.XTX.size(0), device=self.XTX.device))[0].t()
+            W = torch.linalg.solve(self.XTy,
+                                   self.XTX + self.lambda_reg * torch.eye(
+                                       self.XTX.size(0), device=self.XTX.device))[0].t()
             self.XTX = None
             self.XTy = None
 


### PR DESCRIPTION
Newer PyTorch versions no longer support `torch.solve()`. The function that replaces it is available since PyTorch 1.9.0.

This is similar to `torch.eig()` that was also no longer supported. Here it's enough though to just replace `torch.solve()` with `torch.linalg.solve()`.